### PR TITLE
Added support for a different container width

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ var CameraRollPicker = require('react-native-camera-roll-picker');
 - `maximum` : Maximum number of selected images. (Default: 15)
 - `imagesPerRow` : Number of images per row. (Default: 3)
 - `imageMargin` : Margin size of one image. (Default: 5)
+- `containerWidth` : Width of camer roll picker container. (Default: device width)
 - `selectedMarker` : Custom selected image marker component. (Default: checkmark).
 - `backgroundColor` : Set background color. (Default: white).
 

--- a/index.js
+++ b/index.js
@@ -30,8 +30,11 @@ class CameraRollPicker extends Component {
 
   componentWillMount() {
     var {width} = Dimensions.get('window');
-    var {imageMargin, imagesPerRow} = this.props;
+    var {imageMargin, imagesPerRow, containerWidth} = this.props;
 
+    if(typeof containerWidth != "undefined") {
+      width = containerWidth;
+    }
     this._imageSize = (width - (imagesPerRow + 1) * imageMargin) / imagesPerRow;
 
     this.fetch();
@@ -243,6 +246,7 @@ CameraRollPicker.propTypes = {
   ]),
   imagesPerRow: React.PropTypes.number,
   imageMargin: React.PropTypes.number,
+  containerWidth: React.PropTypes.number,
   callback: React.PropTypes.func,
   selected: React.PropTypes.array,
   selectedMarker: React.PropTypes.element,


### PR DESCRIPTION
My app has the image picker in a modal so it's not the device width.  I thought I would share the change I made because I think other people could use it too.