### PR TITLE
Add optional `emptyText` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ var CameraRollPicker = require('react-native-camera-roll-picker');
 - `containerWidth` : Width of camer roll picker container. (Default: device width)
 - `selectedMarker` : Custom selected image marker component. (Default: checkmark).
 - `backgroundColor` : Set background color. (Default: white).
+- `emptyText`: Text to display instead of a list when there are no photos found. (Default: 'No photos.')
+- `emptyTextStyle`: Styles to apply to the `emptyText`. (Default: `textAlign: 'center'`)
 
 ##Run Example
 ```

--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ class CameraRollPicker extends Component {
       imageMargin,
       backgroundColor,
       emptyText,
+      emptyTextStyle,
     } = this.props;
 
     var listViewOrEmptyText = dataSource.getRowCount() > 0 ? (
@@ -117,7 +118,7 @@ class CameraRollPicker extends Component {
         dataSource={dataSource}
         renderRow={rowData => this._renderRow(rowData)} />
     ) : (
-      <Text>{emptyText}</Text>
+      <Text style={[{textAlign: 'center'}, emptyTextStyle]}>{emptyText}</Text>
     );
 
     return (
@@ -274,6 +275,7 @@ CameraRollPicker.propTypes = {
   selectedMarker: React.PropTypes.element,
   backgroundColor: React.PropTypes.string,
   emptyText: React.PropTypes.string,
+  emptyTextStyle: Text.propTypes.style,
 }
 
 CameraRollPicker.defaultProps = {

--- a/index.js
+++ b/index.js
@@ -94,20 +94,36 @@ class CameraRollPicker extends Component {
   }
 
   render() {
-    var {scrollRenderAheadDistance, initialListSize, pageSize, removeClippedSubviews, imageMargin, backgroundColor} = this.props;
+    var {dataSource} = this.state;
+    var {
+      scrollRenderAheadDistance,
+      initialListSize,
+      pageSize,
+      removeClippedSubviews,
+      imageMargin,
+      backgroundColor,
+      emptyText,
+    } = this.props;
+
+    var listViewOrEmptyText = dataSource.getRowCount() > 0 ? (
+      <ListView
+        style={{flex: 1,}}
+        scrollRenderAheadDistance={scrollRenderAheadDistance}
+        initialListSize={initialListSize}
+        pageSize={pageSize}
+        removeClippedSubviews={removeClippedSubviews}
+        renderFooter={this._renderFooterSpinner.bind(this)}
+        onEndReached={this._onEndReached.bind(this)}
+        dataSource={dataSource}
+        renderRow={rowData => this._renderRow(rowData)} />
+    ) : (
+      <Text>{emptyText}</Text>
+    );
+
     return (
       <View
         style={[styles.wrapper, {padding: imageMargin, paddingRight: 0, backgroundColor: backgroundColor},]}>
-        <ListView
-          style={{flex: 1,}}
-          scrollRenderAheadDistance={scrollRenderAheadDistance}
-          initialListSize={initialListSize}
-          pageSize={pageSize}
-          removeClippedSubviews={removeClippedSubviews}
-          renderFooter={this._renderFooterSpinner.bind(this)}
-          onEndReached={this._onEndReached.bind(this)}
-          dataSource={this.state.dataSource}
-          renderRow={rowData => this._renderRow(rowData)} />
+        {listViewOrEmptyText}
       </View>
     );
   }
@@ -257,6 +273,7 @@ CameraRollPicker.propTypes = {
   selected: React.PropTypes.array,
   selectedMarker: React.PropTypes.element,
   backgroundColor: React.PropTypes.string,
+  emptyText: React.PropTypes.string,
 }
 
 CameraRollPicker.defaultProps = {
@@ -275,6 +292,7 @@ CameraRollPicker.defaultProps = {
     console.log(currentImage);
     console.log(selectedImages);
   },
+  emptyText: 'No photos.',
 }
 
 export default CameraRollPicker;


### PR DESCRIPTION
Add an optional `emptyText` prop for when camera roll is empty. Before this change, the list would simply be blank with no indication to the user of what went wrong.

The text defaults to `No photos.` with a default style of `textAlign: 'center'`, but both of these defaults can be overridden.

Tested and verified on both Android and iOS 👍 