### PR TITLE
Add loader prop to show loader during photos fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ import CameraRollPicker from 'react-native-camera-roll-picker';
 - `backgroundColor` : Set background color. (Default: white).
 - `emptyText`: Text to display instead of a list when there are no photos found. (Default: 'No photos.')
 - `emptyTextStyle`: Styles to apply to the `emptyText`. (Default: `textAlign: 'center'`)
+- `loader`: Loader component node. (Default: `<ActivityIndicator />`)
 
 ##Run Example
 ```

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ class CameraRollPicker extends Component {
       images: [],
       selected: this.props.selected,
       lastCursor: null,
+      initialLoading: true,
       loadingMore: false,
       noMore: false,
       dataSource: new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2}),
@@ -66,6 +67,7 @@ class CameraRollPicker extends Component {
     var assets = data.edges;
     var newState = {
       loadingMore: false,
+      initialLoading: false,
     };
 
     if (!data.page_info.has_next_page) {
@@ -94,7 +96,16 @@ class CameraRollPicker extends Component {
       backgroundColor,
       emptyText,
       emptyTextStyle,
+      loader,
     } = this.props;
+
+    if (this.state.initialLoading) {
+      return (
+        <View style={[styles.loader, {backgroundColor}]}>
+          { loader || <ActivityIndicator /> }
+        </View>
+      );
+    }
 
     var listViewOrEmptyText = dataSource.getRowCount() > 0 ? (
       <ListView
@@ -230,7 +241,12 @@ class CameraRollPicker extends Component {
 
 const styles = StyleSheet.create({
   wrapper:{
-    flex: 1,
+    flexGrow: 1,
+  },
+  loader: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   row:{
     flexDirection: 'row',
@@ -273,6 +289,7 @@ CameraRollPicker.propTypes = {
   backgroundColor: React.PropTypes.string,
   emptyText: React.PropTypes.string,
   emptyTextStyle: Text.propTypes.style,
+  loader: React.PropTypes.node,
 }
 
 CameraRollPicker.defaultProps = {


### PR DESCRIPTION
There is "No photos" message during initial photos fetching, which is not a great UX. So it's better to show the customisable loader instead.