### PR TITLE
Migrating from React.PropTypes

### DIFF
--- a/ImageItem.js
+++ b/ImageItem.js
@@ -5,6 +5,7 @@ import {
   Dimensions,
   TouchableOpacity,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 class ImageItem extends Component {
   constructor(props){
@@ -65,12 +66,12 @@ ImageItem.defaultProps = {
 }
 
 ImageItem.propTypes = {
-  item: React.PropTypes.object,
-  selected: React.PropTypes.bool,
-  selectedMarker: React.PropTypes.element,
-  imageMargin: React.PropTypes.number,
-  imagesPerRow: React.PropTypes.number,
-  onClick: React.PropTypes.func,
+  item: PropTypes.object,
+  selected: PropTypes.bool,
+  selectedMarker: PropTypes.element,
+  imageMargin: PropTypes.number,
+  imagesPerRow: PropTypes.number,
+  onClick: PropTypes.func,
 }
 
 export default ImageItem;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ import {
   ListView,
   ActivityIndicator,
 } from 'react-native';
+import PropTypes from 'prop-types';
+
 import ImageItem from './ImageItem';
 
 class CameraRollPicker extends Component {
@@ -244,11 +246,11 @@ const styles = StyleSheet.create({
 })
 
 CameraRollPicker.propTypes = {
-  scrollRenderAheadDistance: React.PropTypes.number,
-  initialListSize: React.PropTypes.number,
-  pageSize: React.PropTypes.number,
-  removeClippedSubviews: React.PropTypes.bool,
-  groupTypes: React.PropTypes.oneOf([
+  scrollRenderAheadDistance: PropTypes.number,
+  initialListSize: PropTypes.number,
+  pageSize: PropTypes.number,
+  removeClippedSubviews: PropTypes.bool,
+  groupTypes: PropTypes.oneOf([
     'Album',
     'All',
     'Event',
@@ -257,21 +259,21 @@ CameraRollPicker.propTypes = {
     'PhotoStream',
     'SavedPhotos',
   ]),
-  maximum: React.PropTypes.number,
-  assetType: React.PropTypes.oneOf([
+  maximum: PropTypes.number,
+  assetType: PropTypes.oneOf([
     'Photos',
     'Videos',
     'All',
   ]),
-  selectSingleItem: React.PropTypes.bool,
-  imagesPerRow: React.PropTypes.number,
-  imageMargin: React.PropTypes.number,
-  containerWidth: React.PropTypes.number,
-  callback: React.PropTypes.func,
-  selected: React.PropTypes.array,
-  selectedMarker: React.PropTypes.element,
-  backgroundColor: React.PropTypes.string,
-  emptyText: React.PropTypes.string,
+  selectSingleItem: PropTypes.bool,
+  imagesPerRow: PropTypes.number,
+  imageMargin: PropTypes.number,
+  containerWidth: PropTypes.number,
+  callback: PropTypes.func,
+  selected: PropTypes.array,
+  selectedMarker: PropTypes.element,
+  backgroundColor: PropTypes.string,
+  emptyText: PropTypes.string,
   emptyTextStyle: Text.propTypes.style,
 }
 


### PR DESCRIPTION
see [FB](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes)
> In 15.5, instead of accessing PropTypes from the main React object, install the prop-types package and import them from there: