### PR TITLE
 This fixes this issue:'Using <Image> with children is deprecated and…

### DIFF
--- a/ImageItem.js
+++ b/ImageItem.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import {
   Image,
+  ImageBackground,
   StyleSheet,
   Dimensions,
   TouchableOpacity,
@@ -37,11 +38,11 @@ class ImageItem extends Component {
       <TouchableOpacity
         style={{marginBottom: imageMargin, marginRight: imageMargin}}
         onPress={() => this._handleClick(image)}>
-        <Image
+        <ImageBackground
           source={{uri: image.uri}}
           style={{height: this._imageSize, width: this._imageSize}} >
           { (selected) ? marker : null }
-        </Image>
+        </ImageBackground>
       </TouchableOpacity>
     );
   }


### PR DESCRIPTION

###  This fixes this issue:'Using <Image> with children is deprecated and will be an error in the near future. Please reconsider the layout or use <ImageBackground> instead.'

### Environment
  
1. `react-native -v`: 0.47.1
2. `node -v`: 6.8.1
3. `npm -v`: 4.1.2


- Target Platform: iphone 6

- Development Operating System: ios 10.3

- Build tools: xcode Version 8.3.2

### Steps to Reproduce
1.Click add button
2.Choose From Library
3.Add the picutures by Clicking,then Chrome dev tool shows the bug
'Using <Image> with children is deprecated and will be an error in the near future. Please reconsider the layout or use <ImageBackground> instead.'
###


