### PR TITLE
Avoid rerender of all images when selecting one

### DIFF
--- a/ImageItem.js
+++ b/ImageItem.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import {
   Image,
   StyleSheet,
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
   },
 });
 
-class ImageItem extends Component {
+class ImageItem extends PureComponent {
   componentWillMount() {
     let { width } = Dimensions.get('window');
     const { imageMargin, imagesPerRow, containerWidth } = this.props;


### PR DESCRIPTION
When there is a long list of images rendered there is a noticeable lag when selecting an image. This is due to the fact that all `ImageItem` components are rerendered. This is simple change to make `ImageItem` a `PureComponent`.