### PR TITLE
Update Example app.

### DIFF
--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="com.example">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
       android:name=".MainApplication"

--- a/Example/package.json
+++ b/Example/package.json
@@ -2,9 +2,10 @@
   "name": "Example",
   "version": "0.0.1",
   "dependencies": {
-    "@react-native-community/cameraroll": "^1.3.0",
+    "@react-native-community/cameraroll": "^4.0.1",
     "react": "16.9.0",
-    "react-native": "0.61.4"
+    "react-native": "0.61.4",
+    "react-native-camera-roll-picker": "../"
   },
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -842,10 +842,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@react-native-community/cameraroll@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-1.3.0.tgz#a340334440f4d08280da839130ef51c931b07483"
-  integrity sha512-QJl9N34euvGU7s/Gn6jhsqi70O4SmxFxuy+yBnW7ehE8qtPYO91gyLLrtiWdTfYvuVCUNvX/G0LKJQLm8SojAA==
+"@react-native-community/cameraroll@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-4.0.1.tgz#8466f99a476e6b833ecd5efff045f74a4224459b"
+  integrity sha512-KLKh5rAg511KUoGKHrbRhBLvkHhOz6kZ2sx8dPhndZ5ZFVYfVpTadSN1x3cfQbOAlkyGZql07p1hk7lEb3sa8g==
 
 "@react-native-community/cli-debugger-ui@^3.0.0":
   version "3.0.0"
@@ -5155,7 +5155,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5224,6 +5224,12 @@ react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-native-camera-roll-picker@../:
+  version "2.0.0"
+  dependencies:
+    "@react-native-community/cameraroll" "^4.0.1"
+    prop-types "^15.6.0"
 
 react-native@0.61.4:
   version "0.61.4"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
     "url": "https://github.com/jeanpan/react-native-camera-roll-picker/issues"
   },
   "dependencies": {
+    "@react-native-community/cameraroll": "^4.0.1",
     "prop-types": "^15.6.0"
-  },
-  "devDependencies": {
-    "@react-native-community/cameraroll": "^1.3.0"
   },
   "homepage": "https://github.com/jeanpan/react-native-camera-roll-picker#readme",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@react-native-community/cameraroll@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-1.3.0.tgz#a340334440f4d08280da839130ef51c931b07483"
-  integrity sha512-QJl9N34euvGU7s/Gn6jhsqi70O4SmxFxuy+yBnW7ehE8qtPYO91gyLLrtiWdTfYvuVCUNvX/G0LKJQLm8SojAA==
+"@react-native-community/cameraroll@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-4.0.1.tgz#8466f99a476e6b833ecd5efff045f74a4224459b"
+  integrity sha512-KLKh5rAg511KUoGKHrbRhBLvkHhOz6kZ2sx8dPhndZ5ZFVYfVpTadSN1x3cfQbOAlkyGZql07p1hk7lEb3sa8g==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
- Update `@react-native-community/cameraroll` from 1.3.0 to 4.0.1.

- Add `READ_EXTERNAL_STORAGE` permission.

- Add relative path to parent directory for `react-native-camera-roll-picker`.
  - This essentially references the parent directory for that package, which is what we want since it ties the Example app to the version of the parent package.


### Before

![BEFORE](https://user-images.githubusercontent.com/180819/101840503-73477100-3b01-11eb-9568-a73af0e355d1.png)


### After

![AFTER](https://user-images.githubusercontent.com/180819/101840516-78a4bb80-3b01-11eb-9c72-4384b695aa0b.png)
