### PR TITLE
Check and requets for read permission on Android.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import {
+  ActivityIndicator,
+  FlatList,
+  PermissionsAndroid,
   Platform,
   StyleSheet,
-  View,
   Text,
-  FlatList,
-  ActivityIndicator,
+  View,
 } from 'react-native';
 import CameraRoll from "@react-native-community/cameraroll";
 import PropTypes from 'prop-types';
@@ -70,7 +71,11 @@ class CameraRollPicker extends Component {
     this.renderImage = this.renderImage.bind(this);
   }
 
-  componentWillMount() {
+  async componentWillMount() {
+    if (Platform.OS === "android" && !(await this.hasAndroidPermission())) {
+      return;
+    }
+
     this.fetch();
   }
 
@@ -78,6 +83,22 @@ class CameraRollPicker extends Component {
     this.setState({
       selected: nextProps.selected,
     });
+  }
+
+  // Ensure we have the correct permissions read external storage on Android (required for Android 10+).
+  // Pulled straight from cameraroll README.
+  // See https://github.com/react-native-cameraroll/react-native-cameraroll#permissions.
+  async hasAndroidPermission() {
+    console.log( "Hello there love!" );
+    const permission = PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE;
+
+    const hasPermission = await PermissionsAndroid.check(permission);
+    if (hasPermission) {
+      return true;
+    }
+
+    const status = await PermissionsAndroid.request(permission);
+    return status === 'granted';
   }
 
   onEndReached() {


### PR DESCRIPTION
This is required on Android 10+.

Otherwise, no images or videos will be shown.

Also confirmed to be working on Android 5, which doesn't show the request if the permission is already added to the app's AndroidManifest file.

The check and request method was pulled directly from cameraroll's README, with the exception of just checking the READ permission instead of the WRITE permission:

https://github.com/react-native-cameraroll/react-native-cameraroll#permissions.

### On First Launch

![Permissions](https://user-images.githubusercontent.com/180819/101840559-94a85d00-3b01-11eb-9ce7-47f28f9e0697.png)

### After Deny and Relaunch

![Permissions denied the first time](https://user-images.githubusercontent.com/180819/101840637-b6094900-3b01-11eb-849b-60c59edc0796.png)


### After Allow

![AFTER Android 10](https://user-images.githubusercontent.com/180819/101840583-9f62f200-3b01-11eb-9281-d2e16a0e6905.png)



