### PR TITLE
Changed(): Update React Native Camera Roll

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -2,7 +2,7 @@
   "name": "Example",
   "version": "0.0.1",
   "dependencies": {
-    "@react-native-community/cameraroll": "^1.3.0",
+    "@react-native-camera-roll/camera-roll": "^5.2.4",
     "react": "16.9.0",
     "react-native": "0.61.4"
   },

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -842,10 +842,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@react-native-community/cameraroll@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-1.3.0.tgz#a340334440f4d08280da839130ef51c931b07483"
-  integrity sha512-QJl9N34euvGU7s/Gn6jhsqi70O4SmxFxuy+yBnW7ehE8qtPYO91gyLLrtiWdTfYvuVCUNvX/G0LKJQLm8SojAA==
+"@react-native-camera-roll/camera-roll@^5.2.4":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@react-native-camera-roll/camera-roll/-/camera-roll-5.2.4.tgz#216d0ea4656b6538c10b60f057118c6f5e704c0d"
+  integrity sha512-pEQDartgO8Nqy6QDm1efvIPpv4q5W+AtTgS05JGK/9x8VzSj8fJ/cvHmMZBlm/4sFpJyvJZ+1KYxKsvFJLbGuQ==
 
 "@react-native-community/cli-debugger-ui@^3.0.0":
   version "3.0.0"

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import {
   FlatList,
   ActivityIndicator,
 } from 'react-native';
-import CameraRoll from "@react-native-community/cameraroll";
+import { CameraRoll } from "@react-native-camera-roll/camera-roll";
 import PropTypes from 'prop-types';
 import Row from './Row';
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prop-types": "^15.6.0"
   },
   "devDependencies": {
-    "@react-native-community/cameraroll": "^1.3.0"
+    "@react-native-camera-roll/camera-roll": "^5.2.4"
   },
   "homepage": "https://github.com/jeanpan/react-native-camera-roll-picker#readme",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@react-native-community/cameraroll@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cameraroll/-/cameraroll-1.3.0.tgz#a340334440f4d08280da839130ef51c931b07483"
-  integrity sha512-QJl9N34euvGU7s/Gn6jhsqi70O4SmxFxuy+yBnW7ehE8qtPYO91gyLLrtiWdTfYvuVCUNvX/G0LKJQLm8SojAA==
+"@react-native-camera-roll/camera-roll@^5.2.4":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@react-native-camera-roll/camera-roll/-/camera-roll-5.2.4.tgz#216d0ea4656b6538c10b60f057118c6f5e704c0d"
+  integrity sha512-pEQDartgO8Nqy6QDm1efvIPpv4q5W+AtTgS05JGK/9x8VzSj8fJ/cvHmMZBlm/4sFpJyvJZ+1KYxKsvFJLbGuQ==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Currently the react native library `@react-native-community/cameraroll` is [deprecated according to npm](https://www.npmjs.com/package/@react-native-community/cameraroll). This PR changes the library to the latest one.